### PR TITLE
Merge received message metadata with ours

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -62,11 +62,9 @@ func (s *jobServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
 			data = &pb.Data{
 				MessageId:  uuid.New().String(),
 				ResponseTo: d.GetMessageId(),
-				Metadata: map[string]string{
-					"Content-Type": contentType,
-				},
-				Content:   fileContent.Bytes(),
-				Directive: d.GetMetadata()["return_url"],
+				Metadata:   constructMetadata(d.GetMetadata(), contentType),
+				Content:    fileContent.Bytes(),
+				Directive:  d.GetMetadata()["return_url"],
 			}
 		} else {
 			data = &pb.Data{

--- a/src/util.go
+++ b/src/util.go
@@ -67,3 +67,13 @@ func readOutputFile(filePath string) (*bytes.Buffer, string) {
 	log.Infoln("form-data created, returning body: ", body)
 	return body, writer.Boundary()
 }
+
+func constructMetadata(receivedMetadata map[string]string, contentType string) map[string]string {
+	ourMetadata := map[string]string{
+		"Content-Type": contentType,
+	}
+	for k, v := range receivedMetadata {
+		ourMetadata[k] = v
+	}
+	return ourMetadata
+}


### PR DESCRIPTION
HMS-2042

- [x] Take the incoming metadata and merge it with our own metadata

Our own metadata currently contain only content type. If needed in future, the initial structure `ourMetadata` in `constructMetadata` can be extended.