### PR TITLE
Parse minimal yaml instead of raw bash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ build/*
 .venv3
 .install
 .pre-commit
-development/nginx/command
+development/nginx/data/*
 coverage.out

--- a/development/nginx/command
+++ b/development/nginx/command
@@ -1,7 +1,0 @@
-data='{"alert": false, "summary": "convert2rhel did not detect issues", "report": "", "report_json": {"foo": "bar"}}'
-
-/usr/bin/convert2rhel --help
-/usr/bin/convert2rhel --version
-echo "BEGIN MARKER"
-echo "$data"
-echo "END MARKER"

--- a/development/nginx/data/yaml-file
+++ b/development/nginx/data/yaml-file
@@ -1,0 +1,18 @@
+vars:
+  # Signature to validate that no one tampered with script
+  _insights_signature: |
+    ascii_armored gpg signature
+  _insights_signature_exclude: "/vars/insights_signature,/vars/content_vars"
+  content: |
+    #!/bin/sh
+    data='{"alert": false, "summary": "convert2rhel did not detect issues", "report": "", "report_json": {"foo": "bar"}}'
+    /usr/bin/convert2rhel --help
+    /usr/bin/convert2rhel --version
+    echo "BEGIN MARKER"
+    echo "$data"
+    echo "END MARKER"
+  content_vars:
+    # variables that will be handed to the script as environment vars
+    # will be prefixed with RHC_WORKER_*
+    FOO: bar
+    BAR: foo

--- a/development/nginx/worker.conf
+++ b/development/nginx/worker.conf
@@ -6,7 +6,7 @@ server {
     access_log  /var/log/nginx/host.access.log  main;
     error_log          /var/log/nginx/error.log debug;
 
-    location /command {
+    location /data/ {
         root       /www/data;
     }
 

--- a/development/podman-compose.yml
+++ b/development/podman-compose.yml
@@ -85,7 +85,7 @@ services:
   nginx:
     image: docker.io/nginx:latest
     volumes:
-      - ./nginx/command:/www/data/command:z
+      - ./nginx/data:/www/data/data:z
       - ./nginx/worker.conf:/etc/nginx/conf.d/default.conf:z
     ports:
       - "8000:80"

--- a/development/python/mqtt_publish.py
+++ b/development/python/mqtt_publish.py
@@ -13,10 +13,13 @@ def get_ip_address():
   return host_ip
 
 # This is changed everytime you refresh the box and register the machine again.
-CLIENT_ID = "e9c0d844-1e0d-4829-9faf-5430aec16205"
+CLIENT_ID = "973afbce-19b4-4862-9d7a-6e9d8c410674"
 BROKER = '127.0.0.1'
 BROKER_PORT = 1883
 TOPIC = f"yggdrasil/{CLIENT_ID}/data/in"
+
+# NOTE: currently can be whatever you placed inside devleopment/nginx/data folder
+SERVED_FILENAME = "yaml-file"
 
 MESSAGE = {
   "type": "data",
@@ -24,7 +27,7 @@ MESSAGE = {
   "version": 1,
   "sent": "2021-01-12T14:58:13+00:00", # str(datetime.datetime.now().isoformat()),
   "directive": 'rhc-worker-bash',
-  "content": f'http://{get_ip_address()}:8000/command',
+  "content": f'http://{get_ip_address()}:8000/data/{SERVED_FILENAME}',
   "metadata": {
       "correlation_id": "00000000-0000-0000-0000-000000000000",
       "return_url": f'http://{get_ip_address()}:8000/api/ingress/v1/upload',

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/src/logger.go
+++ b/src/logger.go
@@ -32,7 +32,8 @@ func setupLogger(logFolder string, fileName string) *os.File {
 	if ok {
 		level, ok := log.ParseLevel(yggdLogLevel)
 		if ok != nil {
-			log.Errorf("Could not parse log level '%v'", yggdLogLevel)
+			log.Errorf("Could not parse log level '%v', setting the level to info", yggdLogLevel)
+			log.SetLevel(log.LevelInfo)
 		} else {
 			log.SetLevel(level)
 		}

--- a/src/logger_test.go
+++ b/src/logger_test.go
@@ -12,33 +12,37 @@ func TestSetupLogger(t *testing.T) {
 	// Create a temporary directory for the log folder
 	logFolderName := "log-test"
 	logFileName := "log-file"
-
 	defer os.RemoveAll(logFolderName)
 
-	// Mock the YGG_LOG_LEVEL environment variable
+	// Test case 1: YGG_LOG_LEVEL doesn't exist, info level should be set to info
+	setupLogger(logFolderName, logFileName)
+	level := log.CurrentLevel()
+	if log.CurrentLevel() != log.LevelInfo {
+		t.Errorf("Incorrect log level. Expected: %v, Got: %v", log.LevelInfo, level)
+	}
+	// Test case 2: Unparsable level in env variable
+	os.Setenv("YGG_LOG_LEVEL", "....")
+	setupLogger(logFolderName, logFileName)
+	level = log.CurrentLevel()
+	if log.CurrentLevel() != log.LevelInfo {
+		t.Errorf("Incorrect log level. Expected: %v, Got: %v", log.LevelInfo, level)
+	}
+
+	// Test case 3: Everything set up correctly
 	os.Setenv("YGG_LOG_LEVEL", "debug")
-	defer os.Unsetenv("YGG_LOG_LEVEL")
 
-	// Call the function being tested
 	logfile := setupLogger(logFolderName, logFileName)
-
-	// Verify that the log folder and file were created
 	if _, err := os.Stat(logFolderName); os.IsNotExist(err) {
 		t.Errorf("Log folder not created: %v", err)
 	}
-
 	logFilePath := filepath.Join(logFolderName, logFileName)
 	if _, err := os.Stat(logFilePath); os.IsNotExist(err) {
 		t.Errorf("Log file not created: %v", err)
 	}
-
-	// Verify that the log level was set correctly
-	level := log.CurrentLevel()
+	level = log.CurrentLevel()
 	if level != log.LevelDebug {
 		t.Errorf("Incorrect log level. Expected: %v, Got: %v", log.LevelDebug, level)
 	}
-
-	// Verify that the log flags were set correctly
 	flags := log.Flags()
 	expectedFlags := log.Lshortfile | log.LstdFlags
 	if flags != expectedFlags {
@@ -46,6 +50,7 @@ func TestSetupLogger(t *testing.T) {
 	}
 
 	// Cleanup - close the log file
+	defer os.Unsetenv("YGG_LOG_LEVEL")
 	err := logfile.Close()
 	if err != nil {
 		t.Errorf("Failed to close log file: %v", err)

--- a/src/main.go
+++ b/src/main.go
@@ -12,24 +12,23 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Initialized in main
 var yggdDispatchSocketAddr string
 var logFolder string
 var logFileName string
 var temporaryWorkerDirectory string
+var shouldDoInsightsCoreGPGCheck string
+var shouldVerifyYaml string
 
 // main is the entry point of the application. It initializes values from the environment,
 // sets up the logger, establishes a connection with the dispatcher, registers as a handler,
 // listens for incoming messages, and starts accepting connections as a Worker service.
 // Note: The function blocks and runs indefinitely until the server is stopped.
 func main() {
-	// Get initialization values from the environment.
-	yggdDispatchSocketAddr, yggSocketAddrExists := os.LookupEnv("YGG_SOCKET_ADDR")
-	if !yggSocketAddrExists {
-		log.Fatal("Missing YGG_SOCKET_ADDR environment variable")
+	initializedOK, errorMsg := initializeEnvironment()
+	if errorMsg != "" && !initializedOK {
+		log.Fatal(errorMsg)
 	}
-	logFolder = getEnv("RHC_WORKER_BASH_LOG_FOLDER", "/var/log/rhc-worker-bash")
-	logFileName = getEnv("RHC_WORKER_BASH_LOG_FILENAME", "rhc-worker-bash.log")
-	temporaryWorkerDirectory = getEnv("RHC_WORKER_BASH_TMP_DIR", "/var/lib/rhc-worker-bash")
 
 	logFile := setupLogger(logFolder, logFileName)
 	defer logFile.Close()

--- a/src/runner.go
+++ b/src/runner.go
@@ -1,19 +1,134 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"strings"
 
 	"git.sr.ht/~spc/go-log"
+	"gopkg.in/yaml.v3"
 )
 
-// Executes bash script and returns its standard output
-func executeScript(fileName string) string {
-	out, err := exec.Command("/bin/sh", fileName).Output()
+// Received Yaml data has to match the expected yamlConfig structure
+type yamlConfig struct {
+	Vars struct {
+		InsightsSignature        string            `yaml:"_insights_signature"`
+		InsightsSignatureExclude string            `yaml:"_insights_signature_exclude"`
+		Content                  string            `yaml:"content"`
+		ContentVars              map[string]string `yaml:"content_vars"`
+	} `yaml:"vars"`
+}
+
+// Verify that no one tampered with yaml file
+func verifyYamlFile(yamlData []byte) bool {
+
+	if shouldVerifyYaml != "1" {
+		log.Warnln("WARNING: Playbook verification disabled.")
+		return true
+	}
+
+	log.Infoln("Verifying yaml file...")
+	// --payload here will be a no-op because no upload is performed when using the verifier
+	//   but, it will allow us to update the egg!
+
+	args := []string{
+		"-m", "insights.client.apps.ansible.playbook_verifier",
+		"--quiet", "--payload", "noop", "--content-type", "noop",
+	}
+	env := os.Environ()
+
+	if shouldDoInsightsCoreGPGCheck == "0" {
+		args = append(args, "--no-gpg")
+		env = append(env, "BYPASS_GPG=True")
+	}
+
+	cmd := exec.Command("insights-client", args...)
+	cmd.Env = env
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		log.Errorln(err)
+		return false
+	}
+
+	// Send yaml data to the command's stdin
+	_, err = stdin.Write(yamlData)
+	if err != nil {
+		log.Errorln(err)
+		return false
+	}
+	stdin.Close()
+
+	output, err := cmd.Output()
+	if err != nil {
+		log.Errorln("ERROR: Unable to verify yaml file:", string(output), err)
+		return false
+	}
+	return true
+}
+
+// Parses given yaml data.
+// If signature is valid then extracts the bash script to temporary file,
+// sets env variables if present and then runs the script.
+// Return stdout of executed script or error message if the signature wasn't valid.
+func processSignedScript(yamlFileContet []byte) string {
+	signatureIsValid := verifyYamlFile(yamlFileContet)
+	if !signatureIsValid {
+		errorMsg := "Signature of yaml file is invalid"
+		log.Errorln(errorMsg)
+		return errorMsg
+	}
+	log.Infoln("Signature of yaml file is valid")
+
+	// Parse the YAML data into the yamlConfig struct
+	var yamlContent yamlConfig
+	err := yaml.Unmarshal(yamlFileContet, &yamlContent)
+	if err != nil {
+		log.Errorln(err)
+	}
+
+	// Set env variables
+	getEnvVarName := func(key string) string {
+		return fmt.Sprintf("RHC_WORKER_%s", strings.ToUpper(key))
+	}
+	for key, value := range yamlContent.Vars.ContentVars {
+		prefixedKey := getEnvVarName(key)
+		err := os.Setenv(prefixedKey, value)
+		if err != nil {
+			log.Errorln(err)
+		} else {
+			log.Infoln("Successfully set env variable", prefixedKey, "=", value)
+		}
+	}
+	defer func() {
+		for key := range yamlContent.Vars.ContentVars {
+			os.Unsetenv(getEnvVarName(key))
+		}
+	}()
+
+	// NOTE: just debug to see the values
+	log.Debugln("Insights Signature:", yamlContent.Vars.InsightsSignature)
+	log.Debugln("Insights Signature Exclude:", yamlContent.Vars.InsightsSignatureExclude)
+	log.Debugln("Script:", yamlContent.Vars.Content)
+	log.Debugln("Vars:")
+	for key, value := range yamlContent.Vars.ContentVars {
+		log.Debugln(" ", key, ":", value)
+	}
+
+	// Write the file contents to the temporary disk
+	log.Infoln("Writing temporary bash script")
+	scriptFileName := writeFileToTemporaryDir([]byte(yamlContent.Vars.Content), temporaryWorkerDirectory)
+	defer os.Remove(scriptFileName)
+
+	// Execute the script
+	log.Infoln("Executing bash script")
+
+	out, err := exec.Command("/bin/sh", scriptFileName).Output()
 	if err != nil {
 		log.Errorln("Failed to execute script: ", err)
 		return ""
 	}
 
-	log.Infoln("Bash script executed successfully.")
+	log.Infoln("Bash script executed successfully")
 	return string(out)
 }

--- a/src/server.go
+++ b/src/server.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
@@ -11,6 +10,34 @@ import (
 	pb "github.com/redhatinsights/yggdrasil/protocol"
 	"google.golang.org/grpc"
 )
+
+// Create message payload
+func createDataMessage(commandOutput string, metadata map[string]string, directive string, messageID string) *pb.Data {
+	correlationID := metadata["correlation_id"]
+	metadataContentType := metadata["return_content_type"]
+	fileContent, boundary := getOutputFile(commandOutput, correlationID, metadataContentType)
+
+	var data *pb.Data
+	if commandOutput != "" && fileContent != nil {
+		contentType := fmt.Sprintf("multipart/form-data; boundary=%s", boundary)
+		log.Infof("Sending message to %s", messageID)
+		data = &pb.Data{
+			MessageId:  uuid.New().String(),
+			ResponseTo: messageID,
+			Metadata:   constructMetadata(metadata, contentType),
+			Content:    fileContent.Bytes(),
+			Directive:  metadata["return_url"],
+		}
+	} else {
+		data = &pb.Data{
+			MessageId:  uuid.New().String(),
+			ResponseTo: messageID,
+			Metadata:   metadata,
+			Directive:  directive,
+		}
+	}
+	return data
+}
 
 // jobServer implements the Worker gRPC service as defined by the yggdrasil
 // gRPC protocol. It accepts Assignment messages, unmarshals the data into a
@@ -33,14 +60,8 @@ type jobServer struct {
 //  6. Sends the data message using the "Send" method of the Dispatcher service.
 func (s *jobServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
 	go func() {
-		log.Infoln("Writing temporary bash script.")
-		// Write the file contents to the temporary disk
-		scriptFileName := writeFileToTemporaryDir(d.GetContent(), temporaryWorkerDirectory)
-		defer os.Remove(scriptFileName)
-
-		log.Infoln("Executing and reading output of bash script located at: ", scriptFileName)
-		// Execute the script we wrote to the file
-		commandOutput := executeScript(scriptFileName)
+		log.Infoln("Processing received yaml data")
+		commandOutput := processSignedScript(d.GetContent())
 
 		// Dial the Dispatcher and call "Finish"
 		conn, err := grpc.Dial(yggdDispatchSocketAddr, grpc.WithInsecure())
@@ -56,30 +77,7 @@ func (s *jobServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
 
 		// Create a data message to send back to the dispatcher.
 		log.Infof("Creating payload for message %s", d.GetMessageId())
-
-		correlationID := d.GetMetadata()["correlation_id"]
-		metadataContentType := d.GetMetadata()["return_content_type"]
-		fileContent, boundary := getOutputFile(scriptFileName, commandOutput, correlationID, metadataContentType)
-
-		var data *pb.Data
-		if commandOutput != "" && fileContent != nil {
-			contentType := fmt.Sprintf("multipart/form-data; boundary=%s", boundary)
-			log.Infof("Sending message to %s", d.GetMessageId())
-			data = &pb.Data{
-				MessageId:  uuid.New().String(),
-				ResponseTo: d.GetMessageId(),
-				Metadata:   constructMetadata(d.GetMetadata(), contentType),
-				Content:    fileContent.Bytes(),
-				Directive:  d.GetMetadata()["return_url"],
-			}
-		} else {
-			data = &pb.Data{
-				MessageId:  uuid.New().String(),
-				ResponseTo: d.GetMessageId(),
-				Metadata:   d.GetMetadata(),
-				Directive:  d.GetDirective(),
-			}
-		}
+		data := createDataMessage(commandOutput, d.GetMetadata(), d.GetDirective(), d.GetMessageId())
 
 		// Call "Send"
 		log.Infof("Sending message to %s", d.GetMessageId())

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCreateDataMessage(t *testing.T) {
+	// Test case 1: commandOutput is not empty
+	commandOutput := "Output of the command"
+	metadata := map[string]string{
+		"correlation_id":      "123",
+		"return_content_type": "application/json",
+		"return_url":          "example.com",
+	}
+	directive := "Directive value"
+	messageID := "Message ID"
+
+	data := createDataMessage(commandOutput, metadata, directive, messageID)
+
+	expectedCorrelationID := "123"
+	if data.Metadata["correlation_id"] != expectedCorrelationID {
+		t.Errorf("Expected correlation_id to be %s, but got %s", expectedCorrelationID, data.Metadata["correlation_id"])
+	}
+
+	expectedMessageType := "multipart/form-data"
+	if !strings.HasPrefix(data.Metadata["Content-Type"], expectedMessageType) {
+		t.Errorf("Expected Content-Type to have prefix %s, but got %s", expectedMessageType, data.Metadata["Content-Type"])
+	}
+
+	expectedDirective := "example.com"
+	if data.Directive != expectedDirective {
+		t.Errorf("Expected Directive to be %s, but got %s", expectedDirective, data.Directive)
+	}
+
+	expectedMessageID := messageID
+	if data.ResponseTo != expectedMessageID {
+		t.Errorf("Expected ResponseTo to be %s, but got %s", expectedMessageID, data.ResponseTo)
+	}
+
+	commandOutput = ""
+	data = createDataMessage(commandOutput, metadata, directive, messageID)
+	if data.Directive != directive {
+		t.Errorf("Expected Directive to be %s, but got %s", directive, data.Directive)
+	}
+	if string(data.Content) != "" {
+		t.Errorf("Expected Content to be empty, but got %s", data.Content)
+	}
+}


### PR DESCRIPTION
[HMS-1994](https://issues.redhat.com/browse/HMS-1994)

- [x] The worker shall receive the data in a playbook-like format and use insights-client to verify the signature
- [x] The worker verifies that nobody has tampered with the contents of the bash script
  - Done similarly like for [rhc-worker-playbook ](https://github.com/RedHatInsights/rhc-worker-playbook/blob/main/rhc_worker_playbook/server.py#L185)
- [x] Prepend all variables located under /vars/content_vars with RHC_WORKER_* and set them in the unix environment
- [x] Include a go-yaml library in the project to process the incoming yaml.