### PR TITLE
Handle interrupt signals

### DIFF
--- a/development/nginx/data/yaml-file
+++ b/development/nginx/data/yaml-file
@@ -5,11 +5,11 @@ vars:
   _insights_signature_exclude: "/vars/insights_signature,/vars/content_vars"
   content: |
     #!/bin/sh
-    data='{"alert": false, "summary": "convert2rhel did not detect issues", "report": "", "report_json": {"foo": "bar"}}'
-    /usr/bin/convert2rhel --help
-    /usr/bin/convert2rhel --version
     echo "BEGIN MARKER"
-    echo "$data"
+    for ((i=1; i<=30; i++)); do
+        echo "Hello, World! $i"
+        sleep 1
+    done
     echo "END MARKER"
   content_vars:
     # variables that will be handed to the script as environment vars

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	git.sr.ht/~spc/go-log v0.0.0-20230531172318-1397be06f5f4
 	github.com/google/uuid v1.3.0
 	github.com/redhatinsights/yggdrasil v0.0.0-20210811162724-41397343c25b
+	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.51.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eclipse/paho.mqtt.golang v1.3.5/go.mod h1:eTzb4gxwwyWpqBUHGQZ4ABAV7+Jgm1PklsYT/eo8Hcc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -57,6 +58,7 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/redhatinsights/yggdrasil v0.0.0-20210811162724-41397343c25b h1:n4f8AXzi7ZjLdAlhAariD4Ya79DL2Kxjc/xDWtSCaSo=
@@ -67,6 +69,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/src/server.go
+++ b/src/server.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
@@ -40,6 +43,47 @@ func createDataMessage(commandOutput string, metadata map[string]string, directi
 	return data
 }
 
+// Processes signed script and sends message back to dispatcher
+func processData(bashScriptContext context.Context, cancel context.CancelFunc, d *pb.Data) {
+	log.Infoln("Processing received yaml data")
+	commandOutput := processSignedScript(bashScriptContext, d.GetContent())
+	cancel()
+
+	// Create a data message to send back to the dispatcher.
+	log.Infof("Creating payload for message %s", d.GetMessageId())
+	data := createDataMessage(commandOutput, d.GetMetadata(), d.GetDirective(), d.GetMessageId())
+	sendDataToDispatcher(data)
+}
+
+// Sends data back to dispatcher
+func sendDataToDispatcher(data *pb.Data) {
+	// Dial the Dispatcher and call "Finish"
+	conn, err := grpc.Dial(yggdDispatchSocketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		log.Error(err)
+	}
+	defer conn.Close()
+
+	// Create a client of the Dispatch service
+	client := pb.NewDispatcherClient(conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	// Call "Send"
+	log.Infof("Sending response message to %s", data.GetResponseTo())
+	log.Infoln("pb.Data message: ", data)
+	if _, err := client.Send(ctx, data); err != nil {
+		log.Error(err)
+	}
+}
+
+// Listens for termination signals on given channel and cancels context if signal is received
+func listenForTerminationSignal(sigCh chan os.Signal, cancel context.CancelFunc) {
+	<-sigCh
+	log.Infoln("Received termination signal. Cancelling...")
+	cancel()
+}
+
 // jobServer implements the Worker gRPC service as defined by the yggdrasil
 // gRPC protocol. It accepts Assignment messages, unmarshals the data into a
 // string, and echoes the content back to the Dispatch service by calling the
@@ -59,36 +103,18 @@ type jobServer struct {
 //  4. Creates a client of the Dispatcher service.
 //  5. Constructs a data message to send back to the dispatcher.
 //  6. Sends the data message using the "Send" method of the Dispatcher service.
-func (s *jobServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
-	go func() {
-		log.Infoln("Processing received yaml data")
-		commandOutput := processSignedScript(d.GetContent())
+func (s *jobServer) Send(_ context.Context, d *pb.Data) (*pb.Receipt, error) {
+	// Create a context with cancellation capability.
+	ctx, cancel := context.WithCancel(context.Background())
 
-		// Dial the Dispatcher and call "Finish"
-		conn, err := grpc.Dial(
-			yggdDispatchSocketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-		if err != nil {
-			log.Error(err)
-		}
-		defer conn.Close()
+	// Set up a signal channel to listen for termination signals.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 
-		// Create a client of the Dispatch service
-		c := pb.NewDispatcherClient(conn)
-		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-		defer cancel()
-
-		// Create a data message to send back to the dispatcher.
-		log.Infof("Creating payload for message %s", d.GetMessageId())
-		data := createDataMessage(
-			commandOutput, d.GetMetadata(), d.GetDirective(), d.GetMessageId())
-
-		// Call "Send"
-		log.Infof("Sending message to %s", d.GetMessageId())
-		log.Infoln("pb.Data message: ", data)
-		if _, err := c.Send(ctx, data); err != nil {
-			log.Error(err)
-		}
-	}()
+	// 1. Goroutine listening for signal
+	go listenForTerminationSignal(sigCh, cancel)
+	// 2. Goroutine processing the data, cancels the context when processing is done
+	go processData(ctx, cancel, d)
 
 	// Respond to the start request that the work was accepted.
 	return &pb.Receipt{}, nil

--- a/src/server_test.go
+++ b/src/server_test.go
@@ -1,8 +1,15 @@
 package main
 
 import (
+	"context"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
+
+	pb "github.com/redhatinsights/yggdrasil/protocol"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateDataMessage(t *testing.T) {
@@ -46,4 +53,45 @@ func TestCreateDataMessage(t *testing.T) {
 	if string(data.Content) != "" {
 		t.Errorf("Expected Content to be empty, but got %s", data.Content)
 	}
+}
+
+func TestListenForTerminationSignal(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	sigCh := make(chan os.Signal, 1)
+
+	go listenForTerminationSignal(sigCh, cancel)
+
+	// Simulate the OS signal by sending SIGINT (Ctrl+C)
+	sigCh <- syscall.SIGINT
+
+	// Wait for a short duration to allow the goroutine to handle the signal and cancel the context
+	time.Sleep(100 * time.Millisecond)
+
+	// Check if the context has been canceled as expected
+	assert.True(t, ctx.Err() != nil, "Context should be canceled")
+}
+
+func TestProcessData(t *testing.T) {
+	// FIXME: this should ideally test that all correct functions are called
+	// Probably easiest would be to move them to interface and then make the function argument take mock interface
+	yggdDispatchSocketAddr = "mock-target"
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	testData := &pb.Data{
+		Content: []byte("Your YAML content"),
+		Metadata: map[string]string{
+			"return_content_type": "foo",
+			"return_url":          "bar",
+			"correlation_id":      "000",
+		},
+		Directive: "Your directive",
+		MessageId: "Your message ID",
+	}
+
+	processData(ctx, cancel, testData)
+
+	// Check if the context has been canceled as expected
+	assert.True(t, ctx.Err() != nil, "Context should be canceled")
 }


### PR DESCRIPTION
[HMS-1998](https://issues.redhat.com/browse/HMS-1998)

- [x] Handle the signals that could kill the worker and submit the same signal to the bash script executing in the background 
  - It is also submitted to the verification call (if verification enabled)
- [x] tests - minimal test, I assume this will be properly tested with integration tests