### PR TITLE
Add dependabot and update golint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/development/python"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,6 +34,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
+    - staticcheck
     - nilerr
     - revive
     - typecheck


### PR DESCRIPTION
[HMS-2162](https://issues.redhat.com/browse/HMS-2162)

- [x] Dependabot added
- [x] Relevant static analysis tools added
  - I only added staticcheck to golang-ci as enabled linter, otherwise it can be seen  in the config that most of the basic linter are already enabled, see all available options at [golangci-lint docs](https://golangci-lint.run/usage/linters/)