### PR TITLE
Add option to create config for rhc-worker-bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,39 @@ vars:
     FOO: bar
     BAR: foo
 ```
-### Environment variables
+## FAQ
 
-Environment variables used by our worker are always prefixed with `RHC_WORKER_`.
+### Are there special environment variables that worker uses?
 
-Use below variables to adjust worker behavior.
-* Related to logging
-  * `RHC_WORKER_LOG_FOLDER` - default is `"/var/log/rhc-worker-bash"`
-  * `RHC_WORKER_LOG_FILENAME` - default is `"rhc-worker-bash.log"`
-* Related to verification of yaml file containing bash script
-  * `RHC_WORKER_GPG_CHECK` - default is `"1"`
-  * `RHC_WORKER_VERIFY_YAML` - default is `"1"`
-* Related to script temporary location and execution
-  * `RHC_WORKER_TMP_DIR` - default is `"/var/lib/rhc-worker-bash"`
+There is one special variable that must be set in order to run our worker and that is `YGG_SOCKET_ADDR`, this variable value is set by `rhcd` via `--socket-addr` option.
+
+Other than that there are no special variables, however if executed bash script contained some `content_vars` (like the example above), then during the execution of the script are all environment variables always prefixed with `RHC_WORKER_`and unset after the bash script completes.
+
+### Can I somehow change behavior of worker? e.g. different destination for logs?
+
+Yes, some values can be changed if config exists at `/etc/rhc/workers/rhc-worker-bash.yml`, **the config must have valid yaml format**, see all available fields below.
+
+Example of full config (with default values):
+```yaml
+# rhc-worker-bash configuration
+
+# recipient directive to register with dispatcher
+directive: "rhc-worker-bash"
+
+# whether to verify incoming yaml files
+verify_yaml: true
+
+# perform the insights-client GPG check on the insights-core egg
+insights_core_gpg_check: true
+
+# temporary directory in which the temporary files with executed bash scripts are created
+temporary_worker_directory: "/var/lib/rhc-worker-bash"
+
+# Options to adjust name and directory for worker logs
+log_dir: "/var/log/rhc-worker-bash"
+log_filename: "rhc-worker-bash.log"
+```
+
+### Can I change the location of rhc-worker bash config?
+
+No, not right now. If you want this feature please create an issue or upvote already existing issue.

--- a/src/runner_test.go
+++ b/src/runner_test.go
@@ -6,13 +6,19 @@ import (
 )
 
 func TestProcessSignedScript(t *testing.T) {
-	temporaryWorkerDirectory = "test-dir"
+	shouldVerifyYaml := false
+	shouldDoInsightsCoreGPGCheck := false
+	temporaryWorkerDirectory := "test-dir"
+	config = &Config{
+		VerifyYAML:               &shouldVerifyYaml,
+		TemporaryWorkerDirectory: &temporaryWorkerDirectory,
+		InsightsCoreGPGCheck:     &shouldDoInsightsCoreGPGCheck,
+	}
+
 	defer os.RemoveAll(temporaryWorkerDirectory)
 
 	// Test case 1: verification disabled, no yaml data supplied = empty output
-	shouldVerifyYaml = "0"
 	yamlData := []byte{}
-
 	expectedResult := ""
 	result := processSignedScript(yamlData)
 	if result != expectedResult {
@@ -38,8 +44,8 @@ vars:
 
 	// FIXME: This is false success because verification fails on missing insighs-client
 	// Test case 3: verification enabled, invalid signature = error msg returned
-	shouldVerifyYaml = "1"
-	shouldDoInsightsCoreGPGCheck = "0"
+	shouldVerifyYaml = true
+	shouldDoInsightsCoreGPGCheck = true
 	expectedResult = "Signature of yaml file is invalid"
 	result = processSignedScript(yamlData)
 	if result != expectedResult {
@@ -48,16 +54,22 @@ vars:
 }
 
 func TestVerifyYamlFile(t *testing.T) {
-	// Test case 1: shouldVerifyYaml is not "1"
-	shouldVerifyYaml = "0"
+	shouldVerifyYaml := false
+	shouldDoInsightsCoreGPGCheck := false
+
+	config = &Config{
+		VerifyYAML:           &shouldVerifyYaml,
+		InsightsCoreGPGCheck: &shouldDoInsightsCoreGPGCheck,
+	}
+	// Test case 1: verification disabled
 	expectedResult := true
 	result := verifyYamlFile([]byte{})
 	if result != expectedResult {
 		t.Errorf("Expected %v, but got %v", expectedResult, result)
 	}
 
-	// Test case 2: shouldVerifyYaml is "1" and verification succeeds
-	shouldVerifyYaml = "1"
+	// Test case 2: verification enabled and verification succeeds
+	shouldVerifyYaml = true
 	// FIXME: This should succedd but now verification fails on missing insighs-client
 	// We also need valid signature
 	expectedResult = false
@@ -67,8 +79,8 @@ func TestVerifyYamlFile(t *testing.T) {
 	}
 
 	// FIXME: Valid test case but fails because of missing insights-client
-	// Test case 3: shouldVerifyYaml is "1" and verification fails
-	shouldVerifyYaml = "1"
+	// Test case 3: sverification is enabled and verification fails
+	// shouldVerifyYaml = true
 	expectedResult = false
 	result = verifyYamlFile([]byte("invalid-yaml")) // Replace with your YAML data
 	if result != expectedResult {

--- a/src/server.go
+++ b/src/server.go
@@ -65,7 +65,8 @@ func (s *jobServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
 		commandOutput := processSignedScript(d.GetContent())
 
 		// Dial the Dispatcher and call "Finish"
-		conn, err := grpc.Dial(yggdDispatchSocketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.Dial(
+			yggdDispatchSocketAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			log.Error(err)
 		}
@@ -78,7 +79,8 @@ func (s *jobServer) Send(ctx context.Context, d *pb.Data) (*pb.Receipt, error) {
 
 		// Create a data message to send back to the dispatcher.
 		log.Infof("Creating payload for message %s", d.GetMessageId())
-		data := createDataMessage(commandOutput, d.GetMetadata(), d.GetDirective(), d.GetMessageId())
+		data := createDataMessage(
+			commandOutput, d.GetMetadata(), d.GetDirective(), d.GetMessageId())
 
 		// Call "Send"
 		log.Infof("Sending message to %s", d.GetMessageId())


### PR DESCRIPTION
Fixes #41 

Yaml config at `'/etc/rhc/workers/rhc-worker-bash.yml'` can now change behavior of worker, this is similar to rhc-worker-playbook (they have [toml config](https://github.com/RedHatInsights/rhc-worker-playbook/blob/main/rhc-worker-playbook.toml), but since we are already using yaml module our config is also yaml)