### PR TITLE
Revert "Bump thatisuday/go-cross-build from 1.0.2 to 1.1.0"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Generate build files
-        uses: thatisuday/go-cross-build@v1.1.0
+        uses: thatisuday/go-cross-build@v1.0.2
         with:
             platforms: 'linux/amd64'
             package: 'src'


### PR DESCRIPTION
Reverts oamg/rhc-worker-bash#45

We need to keep the go-cross-build as 1.0.2 since there is a problem with the latest release introduced in v1.1.0. And as weird as it seems, v1.0.2 was the latest release for this action. 