### PR TITLE
Use separate environment for every executed command

### DIFF
--- a/src/runner_test.go
+++ b/src/runner_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"testing"
 )
 
@@ -85,5 +86,84 @@ func TestVerifyYamlFile(t *testing.T) {
 	result = verifyYamlFile([]byte("invalid-yaml")) // Replace with your YAML data
 	if result != expectedResult {
 		t.Errorf("Expected %v, but got %v", expectedResult, result)
+	}
+}
+
+// Function to check if one string slice is a subset of another
+// Simple compare isn't enough because environment can change during execution
+func areStringSlicesSubset(subset, full []string) bool {
+	for _, s := range subset {
+		found := false
+		for _, f := range full {
+			if s == f {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSetEnvVariablesForCommand(t *testing.T) {
+	testCases := []struct {
+		name                string
+		variables           map[string]string
+		expected            []string
+		anotherCmdVariables map[string]string // Same variables with different values for another command
+	}{
+		{
+			name: "SettingVariables",
+			variables: map[string]string{
+				"VAR1": "value1",
+				"VAR2": "value2",
+			},
+			expected: []string{
+				"RHC_WORKER_VAR1=value1",
+				"RHC_WORKER_VAR2=value2",
+			},
+			anotherCmdVariables: map[string]string{
+				"VAR1": "another_value1",
+			},
+		},
+		{
+			name:      "EmptyVariables",
+			variables: nil,
+			expected:  nil, // Expect no changes to command's environment in this case
+			anotherCmdVariables: map[string]string{
+				"VAR2": "another_value2",
+			},
+		},
+		// Add more test cases as needed
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			originalEnv := os.Environ()
+			// Create the first dummy command
+			cmd := exec.Command("echo", "Hello, World!")
+			anotherCmd := exec.Command("echo", "Bye, World!")
+
+			// Call the functions to set env variables for the commands
+			setEnvVariablesForCommand(cmd, tc.variables)
+			setEnvVariablesForCommand(anotherCmd, tc.anotherCmdVariables)
+
+			// Check if the global environment variables are unchanged
+			if !areStringSlicesSubset(originalEnv, os.Environ()) {
+				t.Error("Global environment variables have been modified.")
+			}
+
+			// Check if the first command's environment variables have been set correctly
+			if !areStringSlicesSubset(cmd.Env, append(os.Environ(), tc.expected...)) {
+				t.Errorf("Command's environment variables are incorrect. Got: %v, Expected: %v", cmd.Env, append(os.Environ(), tc.expected...))
+			}
+
+			// Check if the second command's environment variables are NOT same as for first command
+			if areStringSlicesSubset(anotherCmd.Env, append(os.Environ(), tc.expected...)) {
+				t.Errorf("Command's environment variables are incorrect. Got: %v, Expected: %v", cmd.Env, append(os.Environ(), tc.expected...))
+			}
+		})
 	}
 }


### PR DESCRIPTION
[HMS-2240](https://issues.redhat.com/browse/HMS-2240)

- [x] Change the way we set the env var from globally to local to the command
- [x] Write unit test to verify that the env var is not present globally
- [x] Look for a way to verify if the env var is set for the command executed only
   - the test verifies that same variables can be set for two different commands with different values 