### PR TITLE
Add setup for sos report

### DIFF
--- a/src/logger.go
+++ b/src/logger.go
@@ -61,19 +61,21 @@ func setupLogger(logFolder string, fileName string) *os.File {
 // setupSosExtrasReport sets up the sos report file for the sos_extra plugin to
 // collect the logs for the worker, which is a special file that points out to
 // the current path of the logfile for the worker.
-func setupSosExtrasReport(fileContent string) {
+func setupSosExtrasReport(logFilePath string) {
 	if err := checkAndCreateDirectory(sosReportFolder); err != nil {
 		log.Error(err)
 	}
 
-	// open sosreport file
 	logFile, err := os.Create(path.Join(sosReportFolder, sosReportFile))
 	if err != nil {
 		log.Error(err)
 	}
 	defer logFile.Close()
 
-	content := fmt.Sprintf(":%s", fileContent)
+	// sosreport expects that the file content will be in the following format:
+	// ":/path/to/your/log/file.{log,txt,...}", this will trigger sosreport to
+	// collect the file without the need to have a special plugin in sosreport.
+	content := fmt.Sprintf(":%s", logFilePath)
 	if _, err := logFile.WriteString(content); err != nil {
 		log.Error(err)
 	}

--- a/src/logger.go
+++ b/src/logger.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path"
@@ -22,8 +23,9 @@ func setupLogger(logFolder string, fileName string) *os.File {
 		}
 	}
 
+	logFilePath := path.Join(logFolder, fileName)
 	// open log file
-	logFile, err := os.Create(path.Join(logFolder, fileName))
+	logFile, err := os.Create(logFilePath)
 	if err != nil {
 		log.Error(err)
 	}
@@ -51,4 +53,28 @@ func setupLogger(logFolder string, fileName string) *os.File {
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
 
 	return logFile
+}
+
+// setupSosExtrasReport sets up the sos report file for the sos_extra plugin to
+// collect the logs for the worker, which is a special file that points out to
+// the current path of the logfile for the worker.
+func setupSosExtrasReport(logFolder string, logFileName string, fileContent string) {
+	// Check if path exists, if not, create it.
+	if _, err := os.Stat(logFolder); err != nil {
+		if err := os.Mkdir(logFolder, os.ModePerm); err != nil {
+			log.Error(err)
+		}
+	}
+
+	// open sosreport file
+	logFile, err := os.Create(path.Join(logFolder, logFileName))
+	if err != nil {
+		log.Error(err)
+	}
+	defer logFile.Close()
+
+	content := fmt.Sprintf(":%s", fileContent)
+	if _, err := logFile.WriteString(content); err != nil {
+		log.Error(err)
+	}
 }

--- a/src/logger_test.go
+++ b/src/logger_test.go
@@ -85,19 +85,19 @@ func TestSetupLogger(t *testing.T) {
 }
 
 func TestSetupSosExtrasReport(t *testing.T) {
-	// Create a temporary directory for the log folder
-	logFolder := t.TempDir()
-	logFileName := "log-file"
-	fileContent := path.Join(logFolder, logFileName, "test-file")
+	// FIXME: We are overriding the globals for the below variables, not the
+	// best approach, but works for now.
+	sosReportFile = "log-file"
+	sosReportFolder = t.TempDir()
+	fileContent := path.Join(sosReportFolder, sosReportFile, "test-file")
 	expectedFileContent := fmt.Sprintf(":%s", fileContent)
-	// defer os.RemoveAll(logFolder)
 
-	setupSosExtrasReport(logFolder, logFileName, fileContent)
-	if _, err := os.Stat(logFolder); os.IsNotExist(err) {
+	setupSosExtrasReport(fileContent)
+	if _, err := os.Stat(sosReportFolder); os.IsNotExist(err) {
 		t.Errorf("Log folder not created: %v", err)
 	}
 
-	logFilePath := filepath.Join(logFolder, logFileName)
+	logFilePath := filepath.Join(sosReportFolder, sosReportFile)
 	if _, err := os.Stat(logFilePath); os.IsNotExist(err) {
 		t.Errorf("SOS report file not created: %v", err)
 	}

--- a/src/logger_test.go
+++ b/src/logger_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -79,5 +81,32 @@ func TestSetupLogger(t *testing.T) {
 				}
 			}()
 		})
+	}
+}
+
+func TestSetupSosExtrasReport(t *testing.T) {
+	// Create a temporary directory for the log folder
+	logFolder := t.TempDir()
+	logFileName := "log-file"
+	fileContent := path.Join(logFolder, logFileName, "test-file")
+	expectedFileContent := fmt.Sprintf(":%s", fileContent)
+	// defer os.RemoveAll(logFolder)
+
+	setupSosExtrasReport(logFolder, logFileName, fileContent)
+	if _, err := os.Stat(logFolder); os.IsNotExist(err) {
+		t.Errorf("Log folder not created: %v", err)
+	}
+
+	logFilePath := filepath.Join(logFolder, logFileName)
+	if _, err := os.Stat(logFilePath); os.IsNotExist(err) {
+		t.Errorf("SOS report file not created: %v", err)
+	}
+
+	logFile, err := os.ReadFile(logFilePath)
+	if err != nil {
+		t.Errorf("Failed to read file: %v", err)
+	}
+	if string(logFile) != expectedFileContent {
+		t.Errorf("File content does not match")
 	}
 }

--- a/src/main.go
+++ b/src/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net"
 	"os"
-	"path"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
@@ -18,8 +17,6 @@ import (
 const configFilePath = "/etc/rhc/workers/rhc-worker-bash.yml"
 const logDir = "/var/log/rhc-worker-bash"
 const logFileName = "rhc-worker-bash.log"
-const sosReportFolder = "/etc/sos.extras.d"
-const sosReportFile = "rhc-worker-logs"
 
 var yggdDispatchSocketAddr string
 var config *Config
@@ -41,7 +38,6 @@ func main() {
 
 	logFile := setupLogger(logDir, logFileName)
 	defer logFile.Close()
-	setupSosExtrasReport(sosReportFolder, sosReportFile, path.Join(logDir, logFileName))
 
 	// Dial the dispatcher on its well-known address.
 	conn, err := grpc.Dial(

--- a/src/main.go
+++ b/src/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"path"
 	"time"
 
 	"git.sr.ht/~spc/go-log"
@@ -17,13 +18,16 @@ import (
 const configFilePath = "/etc/rhc/workers/rhc-worker-bash.yml"
 const logDir = "/var/log/rhc-worker-bash"
 const logFileName = "rhc-worker-bash.log"
+const sosReportFolder = "/etc/sos.extras.d"
+const sosReportFile = "rhc-worker-logs"
 
 var yggdDispatchSocketAddr string
 var config *Config
 
-// main is the entry point of the application. It initializes values from the environment,
-// sets up the logger, establishes a connection with the dispatcher, registers as a handler,
-// listens for incoming messages, and starts accepting connections as a Worker service.
+// main is the entry point of the application. It initializes values from the
+// environment, sets up the logger, establishes a connection with the
+// dispatcher, registers as a handler, listens for incoming messages, and
+// starts accepting connections as a Worker service.
 // Note: The function blocks and runs indefinitely until the server is stopped.
 func main() {
 	var yggSocketAddrExists bool // Has to be separately declared otherwise grpc.Dial doesn't work
@@ -37,6 +41,7 @@ func main() {
 
 	logFile := setupLogger(logDir, logFileName)
 	defer logFile.Close()
+	setupSosExtrasReport(sosReportFolder, sosReportFile, path.Join(logDir, logFileName))
 
 	// Dial the dispatcher on its well-known address.
 	conn, err := grpc.Dial(

--- a/src/util.go
+++ b/src/util.go
@@ -156,3 +156,17 @@ func loadConfigOrDefault(filePath string) *Config {
 	setDefaultValues(config)
 	return config
 }
+
+// Helper function to check if a directory exists, if not, create the
+// directory, otherwise, return nil. If it fails to create the directory, the
+// function will return the error raised by `os.Mkdir` to the caller.
+func checkAndCreateDirectory(folder string) error {
+	// Check if path exists, if not, create it.
+	if _, err := os.Stat(folder); err != nil {
+		if err := os.Mkdir(folder, os.ModePerm); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
SOS Report needs a special file in the /etc/sos.extras.d/ folder to be able to collect the log files for the worker. Since it won't have a special plugin in sosreport due to RHEL 7 being in maintenance mode, we will be using this strategy to make sure that sosreport will be able to collect our logs.