### PR TITLE
Remove unnecessary logging

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -72,7 +72,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Infoln("Listening to messages...", yggdDispatchSocketAddr)
 	// Register as a Worker service with gRPC and start accepting connections.
 	s := grpc.NewServer()
 	pb.RegisterWorkerServer(s, &jobServer{})


### PR DESCRIPTION
This log was placed on main during the early stages of development to figure out if the variables was being set properly, since that part is mostly stable, we can remove this log once for all.